### PR TITLE
fix: undefined dates

### DIFF
--- a/public/js/tabulator.js
+++ b/public/js/tabulator.js
@@ -4,7 +4,13 @@ import { DEPLOYMENT } from "/deployments/selected.js";
 // Formatters specific for use in Tabulator cells, try to reuse
 // utils.formatters as much as possible
 function formatUnixTime(cell, formatterParams, onRendered) {
-  return formatters.unixToISOOnly(cell.getValue());
+  const value = cell.getValue();
+  if (value === undefined || value === null) {
+    return "N/A";
+  } else {
+    return formatters.unixToISOOnly(value);
+  }
+  // return formatters.unixToISOOnly(cell.getValue());
 }
 
 function formatAmount(cell, formatterParams, onRendered) {


### PR DESCRIPTION
When a date is undefined (like with the minipools cycle end date when its in prelaunch or launched status), the date is rendered incorrectly (1/1/1970). This fixes it to render 'N/A' instead.

Closes #9 

Testing:
-  https://cln.sh/K4w6Gm1g
- [x] Date renders N/A when undefined
- [x] Date renders correctly when defined
- [x] Function works on both /home and /pandasia


<img width="1511" alt="CleanShot 2024-04-19 at 07 13 22@2x" src="https://github.com/multisig-labs/Panopticon/assets/99197390/25e4732c-d879-457d-ad76-0ca8824dfa3e">